### PR TITLE
Update GitHub Actions workflow to use actions/upload-pages-artifact@v3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
* Change the version of actions/upload-pages-artifact from v1 to v3 in the `.github/workflows/pages.yml` file